### PR TITLE
fix: drop tidy hook

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,8 +1,4 @@
 # Ref: https://goreleaser.com
-before:
-  hooks:
-    - make fmt vet tidy
-
 builds:
   - id: go-tls-lint
     main: ./cmd/go-tls-lint


### PR DESCRIPTION
goimports is unavailable in github actions